### PR TITLE
Fix/33 record browser column headings

### DIFF
--- a/src/views/record-browser/table-data/table-data.html
+++ b/src/views/record-browser/table-data/table-data.html
@@ -9,11 +9,13 @@
 	</thead>
 	<tbody>
 		<tr ng-repeat="row in tableData.rows">
-			<td ng-if="!tableData.isJson(cell)" ng-repeat="cell in ::row track by $index">
-				{{ ::cell }}
-			</td>
-			<td ng-if="tableData.isJson(cell)" ng-repeat="cell in ::row track by $index">
-				<json-formatter json="cell"></json-formatter>
+			<td ng-repeat="cell in ::row track by $index">
+				<div ng-if="!tableData.isJson(cell)">
+					{{ ::cell }}
+				</div>
+				<div ng-if="tableData.isJson(cell)">
+					<json-formatter json="cell"></json-formatter>
+				</div>
 			</td>
 		</tr>
 	</tbody>

--- a/src/views/record-browser/table-data/table-data.html
+++ b/src/views/record-browser/table-data/table-data.html
@@ -1,18 +1,20 @@
 <table>
 	<thead>
 	<tr>
-		<th
-			ng-repeat="column in tableData.columns"
-			ng-class="{ secondary : column.nonSchema }"
-		>{{ ::column.name }}</th>
+		<th ng-repeat="column in tableData.columns"
+		    ng-class="{ secondary : column.nonSchema }">
+			{{ ::column.name }}
+		</th>
 	</tr>
 	</thead>
 	<tbody>
-	<tr ng-repeat="row in tableData.rows">
-		<td ng-if="!tableData.isJson(cell)" ng-repeat="cell in ::row track by $index">{{ ::cell }}</td>
-		<td ng-if="tableData.isJson(cell)" ng-repeat="cell in ::row track by $index">
-			<json-formatter json="cell"></json-formatter>
-		</td>
-	</tr>
+		<tr ng-repeat="row in tableData.rows">
+			<td ng-if="!tableData.isJson(cell)" ng-repeat="cell in ::row track by $index">
+				{{ ::cell }}
+			</td>
+			<td ng-if="tableData.isJson(cell)" ng-repeat="cell in ::row track by $index">
+				<json-formatter json="cell"></json-formatter>
+			</td>
+		</tr>
 	</tbody>
 </table>

--- a/src/views/record-browser/table-data/table-data.html
+++ b/src/views/record-browser/table-data/table-data.html
@@ -10,12 +10,12 @@
 	<tbody>
 		<tr ng-repeat="row in tableData.rows">
 			<td ng-repeat="cell in ::row track by $index">
-				<div ng-if="!tableData.isJson(cell)">
+				<ng-transclude ng-if="!tableData.isJson(cell)">
 					{{ ::cell }}
-				</div>
-				<div ng-if="tableData.isJson(cell)">
+				</ng-transclude>
+				<ng-transclude ng-if="tableData.isJson(cell)">
 					<json-formatter json="cell"></json-formatter>
-				</div>
+				</ng-transclude>
 			</td>
 		</tr>
 	</tbody>

--- a/src/views/record-browser/table-data/table-data.html
+++ b/src/views/record-browser/table-data/table-data.html
@@ -1,11 +1,11 @@
 <table>
 	<thead>
-	<tr>
-		<th ng-repeat="column in tableData.columns"
-		    ng-class="{ secondary : column.nonSchema }">
-			{{ ::column.name }}
-		</th>
-	</tr>
+		<tr>
+			<th ng-repeat="column in tableData.columns"
+			    ng-class="{ secondary : column.nonSchema }">
+				{{ ::column.name }}
+			</th>
+		</tr>
 	</thead>
 	<tbody>
 		<tr ng-repeat="row in tableData.rows">


### PR DESCRIPTION
Table column headings now always match table data.

Closes #33.
