### PR TITLE
Fix/54 query builder filters

### DIFF
--- a/src/views/record-browser/query-builder/query-builder.component.js
+++ b/src/views/record-browser/query-builder/query-builder.component.js
@@ -67,11 +67,11 @@
 		vm.removeFilter = function(field, filter) {
 
 			// Remove the filter from the filterGroup
-			vm.filterGroups[field] = vm.filterGroups[field].filter((currentFilter => currentFilter !== filter));
+			vm.query.filterGroups[field] = vm.query.filterGroups[field].filter((currentFilter => currentFilter !== filter));
 
 			// Remove the filterGroup if it is empty
-			if(!vm.filterGroups[field].length) {
-				delete vm.filterGroups[field];
+			if(!vm.query.filterGroups[field].length) {
+				delete vm.query.filterGroups[field];
 			}
 		};
 

--- a/src/views/record-browser/query-builder/query-builder.component.js
+++ b/src/views/record-browser/query-builder/query-builder.component.js
@@ -86,7 +86,7 @@
 				for(var field in filterGroups) {
 					if(filterGroups.hasOwnProperty(field)) {
 						filterGroups[field].forEach(({operator, value}) => {
-							filters.push(new montage.Field(field)[operator](value));
+							filters.push(new montage.Field(field)[vm.operatorDictionary[operator]](value));
 						});
 					}
 				}

--- a/src/views/record-browser/query-builder/query-builder.component.js
+++ b/src/views/record-browser/query-builder/query-builder.component.js
@@ -75,7 +75,7 @@
 			}
 		};
 
-		vm.buildQuery = ({ schema, filterGroups, order, limit, offset }) => {
+		vm.buildQuery = ({ schema, filterGroups, order_by, ordering, limit, offset }) => {
 			if(!schema) return;
 
 			var query = new montage.Query(schema);

--- a/src/views/record-browser/query-builder/query-builder.component.js
+++ b/src/views/record-browser/query-builder/query-builder.component.js
@@ -94,7 +94,7 @@
 				query.filter.apply(query, filters);
 			}
 
-			if(order) { query.order(order.field, order.direction); }
+			if (order_by && ordering) { query.orderBy(order_by, ordering); }
 			if(offset) { query.skip(parseInt(offset)); }
 			if(limit) { query.limit(parseInt(limit)); }
 

--- a/src/views/record-browser/query-builder/query-builder.component.js
+++ b/src/views/record-browser/query-builder/query-builder.component.js
@@ -25,7 +25,6 @@
 			'>'                              : 'gt',
 			'>='                             : 'ge',
 			'in'                             : 'inSet',
-			'contains'                       : 'contains',
 			'regex'                          : 'regex',
 			'starts with'                    : 'starts',
 			'starts with (case insensitive)' : 'istarts',


### PR DESCRIPTION
This PR fixes an issue with the query builder filters not working. Some key things were that the `order` was a reference to an outdated API; we weren't mapping to the `operatorDictionary` to pass to the API wrapper; `vm.filterGroups` was actually undefined and was supposed to be `vm.query.filterGroups`.

This PR currently depends on [Elanna's PR on javascript-montage](https://github.com/Montage-Inc/javascript-montage/pull/14). The only thing that won't work until the merge is the `ordering` (`$asc`, or `$desc`). The code conforms to the wrapper and is expected to execute properly when the wrapper is updated.
