### PR TITLE
Feature/71-query-builder-error-messages

### DIFF
--- a/src/static/styles/mixins.scss
+++ b/src/static/styles/mixins.scss
@@ -14,6 +14,7 @@
 }
 
 @mixin scrollable() {
+	height: inherit;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
 }

--- a/src/static/styles/mixins.scss
+++ b/src/static/styles/mixins.scss
@@ -14,7 +14,6 @@
 }
 
 @mixin scrollable() {
-	height: inherit;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
 }

--- a/src/static/styles/variables.scss
+++ b/src/static/styles/variables.scss
@@ -6,7 +6,7 @@ $blue-gray-light: #d0d8de;
 
 $green: #0B9444;
 
-$red: #d4411d;
+$red: #F44336;
 
 $gray-dark: #444;
 $gray-medium: #555;

--- a/src/views/record-browser/record-browser.component.js
+++ b/src/views/record-browser/record-browser.component.js
@@ -18,13 +18,13 @@
 			montageHelper.getClient()
 				.execute({ query })
 				.then(response => {
-					const res = response.data.query;
-					vm.error = res.error;
-					vm.dataExists = !!res.length;
+					const queryResults = response.data.query;
+					vm.error = queryResults.error;
+					vm.dataExists = !!queryResults.length;
 
 					return vm.results = {
 						schema: getSchema(query.schema),
-						documentList: res
+						documentList: queryResults
 					};
 				});
 		};

--- a/src/views/record-browser/record-browser.component.js
+++ b/src/views/record-browser/record-browser.component.js
@@ -19,7 +19,7 @@
 				.execute({ query })
 				.then(response => {
 					const res = response.data.query;
-					vm.err = res.error;
+					vm.error = res.error;
 					vm.dataExists = !!res.length;
 
 					return vm.results = {

--- a/src/views/record-browser/record-browser.component.js
+++ b/src/views/record-browser/record-browser.component.js
@@ -18,9 +18,13 @@
 			montageHelper.getClient()
 				.execute({ query })
 				.then(response => {
+					const res = response.data.query;
+					vm.err = res.error;
+					vm.dataExists = !!res.length;
+
 					return vm.results = {
 						schema: getSchema(query.schema),
-						documentList: response.data.query
+						documentList: res
 					};
 				});
 		};

--- a/src/views/record-browser/record-browser.html
+++ b/src/views/record-browser/record-browser.html
@@ -9,16 +9,16 @@
 		<h1>Use the Query Builder to the left to retrieve your data.</h1>
 	</div>
 
-	<div class="help-text" ng-show="recordBrowser.results && !recordBrowser.dataExists && !recordBrowser.err">
+	<div class="help-text" ng-show="recordBrowser.results && !recordBrowser.dataExists && !recordBrowser.error">
 		<h1 class="info">No results to display</h1>
 	</div>
 
-	<div class="help-text error" ng-show="recordBrowser.err">
+	<div class="help-text error" ng-show="recordBrowser.error">
 		<i class="fa fa-exclamation-circle"></i>
 		<h2 class="error-text">There was an error processing your request.</h2>
 	</div>
 
-	<md-tabs md-dynamic-height ng-show="recordBrowser.results && !recordBrowser.err && recordBrowser.dataExists">
+	<md-tabs md-dynamic-height ng-show="recordBrowser.results && !recordBrowser.error && recordBrowser.dataExists">
 		<md-tab label="Table">
 			<table-data
 				schema-fields="recordBrowser.results.schema.fields"

--- a/src/views/record-browser/record-browser.html
+++ b/src/views/record-browser/record-browser.html
@@ -15,7 +15,7 @@
 
 	<div class="help-text error" ng-show="recordBrowser.err">
 		<i class="fa fa-exclamation-circle"></i>
-		<h2>There was an error processing your request.</h2>
+		<h2 class="error-text">There was an error processing your request.</h2>
 	</div>
 
 	<md-tabs md-dynamic-height ng-show="recordBrowser.results && !recordBrowser.err && recordBrowser.dataExists">

--- a/src/views/record-browser/record-browser.html
+++ b/src/views/record-browser/record-browser.html
@@ -9,8 +9,8 @@
 		<h1>Use the Query Builder to the left to retrieve your data.</h1>
 	</div>
 
-	<div class="help-text" ng-show="recordBrowser.results && !recordBrowser.dataExists && !recordBrowser.error">
-		<h1 class="info">No results to display</h1>
+	<div class="help-text info" ng-show="recordBrowser.results && !recordBrowser.dataExists && !recordBrowser.error">
+		<h1>No results to display</h1>
 	</div>
 
 	<div class="help-text error" ng-show="recordBrowser.error">

--- a/src/views/record-browser/record-browser.html
+++ b/src/views/record-browser/record-browser.html
@@ -9,7 +9,16 @@
 		<h1>Use the Query Builder to the left to retrieve your data.</h1>
 	</div>
 
-	<md-tabs md-dynamic-height ng-show="recordBrowser.results">
+	<div class="help-text" ng-show="recordBrowser.results && !recordBrowser.dataExists && !recordBrowser.err">
+		<h1 class="info">No results to display</h1>
+	</div>
+
+	<div class="help-text error" ng-show="recordBrowser.err">
+		<i class="fa fa-exclamation-circle"></i>
+		<h2>There was an error processing your request.</h2>
+	</div>
+
+	<md-tabs md-dynamic-height ng-show="recordBrowser.results && !recordBrowser.err && recordBrowser.dataExists">
 		<md-tab label="Table">
 			<table-data
 				schema-fields="recordBrowser.results.schema.fields"

--- a/src/views/record-browser/record-browser.scss
+++ b/src/views/record-browser/record-browser.scss
@@ -20,6 +20,25 @@ $sidebar-width: 300px;
 		margin-left: $sidebar-width;
 	}
 
+	.help-text {
+		&.error {
+			background: $red;
+			padding: 15px;
+			margin: (-$padding) (-$padding) 0 ($sidebar-width - $padding);
+
+			& > .error-text,
+			& > .fa {
+				color: $white;
+				display: inline;
+				font-size: 32px;
+			}
+		}
+
+		.info {
+			color: $blue;
+		}
+	}
+
 	.help-text h1 {
 		display: block;
 		text-align: center;

--- a/src/views/record-browser/record-browser.scss
+++ b/src/views/record-browser/record-browser.scss
@@ -40,7 +40,12 @@ $sidebar-width: 300px;
 			& > .fa {
 				color: $white;
 				display: inline;
-				font-size: 32px;
+				font-size: 24px;
+				font-weight: normal;
+			}
+
+			& > .fa {
+				margin-right: 10px;
 			}
 		}
 

--- a/src/views/record-browser/record-browser.scss
+++ b/src/views/record-browser/record-browser.scss
@@ -1,9 +1,11 @@
 @import '../../static/styles/variables';
+@import '../../static/styles/mixins';
 
 $sidebar-width: 300px;
 
 .record-browser-view {
 	query-builder {
+		@include scrollable();
 		position: fixed;
 		top: $header-height;
 		bottom: 0;

--- a/src/views/record-browser/record-browser.scss
+++ b/src/views/record-browser/record-browser.scss
@@ -34,18 +34,21 @@ $sidebar-width: 300px;
 			}
 		}
 
-		.info {
+		&.info {
 			color: $blue;
 		}
 	}
 
-	.help-text h1 {
-		display: block;
-		text-align: center;
+	.help-text {
 		color: $gray-mid-light;
-		max-width: 750px;
-		margin: auto;
-		padding: $padding-large $padding-medium 0;
+
+		h1 {
+			display: block;
+			text-align: center;
+			max-width: 750px;
+			margin: auto;
+			padding: $padding-large $padding-medium 0;
+		}
 	}
 
 	table {

--- a/src/views/record-browser/record-browser.scss
+++ b/src/views/record-browser/record-browser.scss
@@ -32,7 +32,7 @@ $sidebar-width: 300px;
 		}
 
 		&.error {
-			background: $red;
+			background: $danger;
 			padding: 15px;
 			margin: (-$padding) (-$padding) 0 ($sidebar-width - $padding);
 

--- a/src/views/record-browser/record-browser.scss
+++ b/src/views/record-browser/record-browser.scss
@@ -21,6 +21,16 @@ $sidebar-width: 300px;
 	}
 
 	.help-text {
+		color: $gray-mid-light;
+
+		h1 {
+			display: block;
+			text-align: center;
+			max-width: 750px;
+			margin: auto;
+			padding: $padding-large $padding-medium 0;
+		}
+
 		&.error {
 			background: $red;
 			padding: 15px;
@@ -36,18 +46,6 @@ $sidebar-width: 300px;
 
 		&.info {
 			color: $blue;
-		}
-	}
-
-	.help-text {
-		color: $gray-mid-light;
-
-		h1 {
-			display: block;
-			text-align: center;
-			max-width: 750px;
-			margin: auto;
-			padding: $padding-large $padding-medium 0;
 		}
 	}
 


### PR DESCRIPTION
- fixed an issue where the `scrollable` mixin wouldn't actually apply to the height of the element applied to. Fixed by adding a height to the mixin
- displays a helpful error message if the error property exists on the executed query
- displays a helpful info message if the query returned no results
- styles for the new messages

closes #71 
